### PR TITLE
fix: paramiko.HostKeyEntry.hostnames is a list

### DIFF
--- a/stubs/paramiko/paramiko/hostkeys.pyi
+++ b/stubs/paramiko/paramiko/hostkeys.pyi
@@ -37,7 +37,7 @@ class InvalidHostKey(Exception):
 
 class HostKeyEntry:
     valid: bool
-    hostnames: str
+    hostnames: list[str]
     key: PKey
     def __init__(self, hostnames: list[str] | None = ..., key: PKey | None = ...) -> None: ...
     @classmethod


### PR DESCRIPTION
See https://github.com/paramiko/paramiko/blob/14fd03ec45fed0546aa01b1ef5ccf84508680e02/paramiko/hostkeys.py#L354-L375

`names = names.split(',')` implies that when `names` is passed to `cls` in line 375, it is no longer a string; it is now an array.

More evidence can be seen in [line 78](https://github.com/paramiko/paramiko/blob/14fd03ec45fed0546aa01b1ef5ccf84508680e02/paramiko/hostkeys.py#L78) where the constructor is passed a singleton list.